### PR TITLE
[#162507264] Add timestamp support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 config.yml
 yet-another-cloudwatch-exporter
 vendor
+/src/yace

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.12.0
+* Add the exact timestamps from CloudWatch to the exporter Prometheus metrics
+* Add a new option `disableTimestamp` to not include a timestamp for a specific metric (it can be useful for sparse metrics, e.g. from S3)
+
 # 0.11.0
 * **BREAKING** Add snake_case to prometheus metrics (sanchezpaco)
 ```yaml

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ YACE is currently in quick iteration mode. Things will probably break in upcomin
 * Filter monitored resources via regex
 * Automatic adding of tag labels to metrics
 * Allows to export 0 even if CloudWatch returns nil
+* Exports metrics with CloudWatch timestamps (can be disabled per-metric)
 * Static metrics support for all cloudwatch metrics without auto discovery
 * Pull data from mulitple AWS accounts using cross-acount roles
 * Supported services with auto discovery through tags:
@@ -30,7 +31,70 @@ YACE is currently in quick iteration mode. Things will probably break in upcomin
 
 ## Configuration
 
-Example of config File
+### Top level configuration
+
+| Key       | Description                   |
+| --------- | ----------------------------- |
+| discovery | Auto-discovery configuration  |
+| static    | List of static configurations |
+
+### Auto-discovery configuration
+
+| Key                   | Description                                       |
+| --------------------- | ------------------------------------------------- |
+| exportedTagsOnMetrics | List of tags per service to export to all metrics |
+| jobs                  | List of auto-discovery jobs                       |
+
+exportedTagsOnMetrics example:
+
+```
+exportedTagsOnMetrics:
+  ec2:
+    - Name
+    - type
+```
+
+### Auto-discovery job
+
+| Key        | Description                                                                              |
+| ---------- | ---------------------------------------------------------------------------------------- |
+| region     | AWS region                                                                               |
+| type       | Service name, e.g. "ec2", "s3", etc.                                                     |
+| roleArn    | IAM role to assume (optional)                                                            |
+| searchTags | List of Key/Value pairs to use for tag filtering (all must match), Value can be a regex. |
+| metrics    | List of metric definitions                                                               |
+
+searchTags example:
+```
+searchTags:
+  - Key: env
+    Value: production
+```
+
+### Metric definition
+
+| Key              | Description                                                                                              |
+| ---------------- | -------------------------------------------------------------------------------------------------------- |
+| name             | CloudWatch metric name                                                                                   |
+| statistics       | List of statictic types, e.g. "Mininum", "Maximum", etc.                                                 |
+| period           | Statictic period                                                                                         |
+| length           | How far back to request data for                                                                         |
+| delay            | If set it will request metrics up until `current_time - delay`                                           |
+| nilToZero        | Return 0 value if Cloudwatch returns no metrics at all                                                   |
+| disableTimestamp | Do not export the metric with the original CloudWatch timestamp (useful for sparse metrics, e.g from S3) |
+
+### Static configuration
+
+| Key        | Description                                                |
+| ---------- | ---------------------------------------------------------- |
+| region     | AWS region                                                 |
+| roleArn    | IAM role to assume                                         |
+| namespace  | CloudWatch namespace                                       |
+| customTags | Custom tags to be added as a list of Key/Value pairs       |
+| dimensions | CloudWatch metric dimensions as a list of Name/Value pairs |
+| metrics    | List of metric definitions                                 |
+
+### Example of config File
 ```
 discovery:
   exportedTagsOnMetrics:
@@ -102,6 +166,18 @@ discovery:
         - 'p90'
         period: 60
         length: 300
+  - type: "s3"
+    region: eu-west-1
+    searchTags:
+      - Key: type
+        Value: public
+    metrics:
+      - name: NumberOfObjects
+        statistics:
+          - Average
+        period: 86400
+        length: 172800
+        disableTimestamp: true
 static:
   - namespace: AWS/AutoScaling
     region: eu-west-1

--- a/src/Gopkg.lock
+++ b/src/Gopkg.lock
@@ -2,6 +2,7 @@
 
 
 [[projects]]
+  digest = "1:a22c709afb7abc23003020a59b4bd04bec903284f58c198c49c0bea7e525fa8e"
   name = "github.com/aws/aws-sdk-go"
   packages = [
     "aws",
@@ -37,85 +38,119 @@
     "service/cloudwatch/cloudwatchiface",
     "service/resourcegroupstaggingapi",
     "service/resourcegroupstaggingapi/resourcegroupstaggingapiiface",
-    "service/sts"
+    "service/sts",
   ]
+  pruneopts = ""
   revision = "bc3f534c19ffdf835e524e11f0f825b3eaf541c3"
   version = "v1.14.31"
 
 [[projects]]
   branch = "master"
+  digest = "1:c0bec5f9b98d0bc872ff5e834fac186b807b656683bd29cb82fb207a1513fabb"
   name = "github.com/beorn7/perks"
   packages = ["quantile"]
+  pruneopts = ""
   revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
 
 [[projects]]
+  digest = "1:858b7fe7b0f4bc7ef9953926828f2816ea52d01a88d72d1c45bc8c108f23c356"
   name = "github.com/go-ini/ini"
   packages = ["."]
+  pruneopts = ""
   revision = "358ee7663966325963d4e8b2e1fbd570c5195153"
   version = "v1.38.1"
 
 [[projects]]
+  digest = "1:f958a1c137db276e52f0b50efee41a1a389dcdded59a69711f3e872757dab34b"
   name = "github.com/golang/protobuf"
   packages = ["proto"]
+  pruneopts = ""
   revision = "b4deda0973fb4c70b50d226b1af49f3da59f5265"
   version = "v1.1.0"
 
 [[projects]]
+  digest = "1:6f49eae0c1e5dab1dafafee34b207aeb7a42303105960944828c2079b92fc88e"
   name = "github.com/jmespath/go-jmespath"
   packages = ["."]
+  pruneopts = ""
   revision = "0b12d6b5"
 
 [[projects]]
+  digest = "1:63722a4b1e1717be7b98fc686e0b30d5e7f734b9e93d7dee86293b6deab7ea28"
   name = "github.com/matttproud/golang_protobuf_extensions"
   packages = ["pbutil"]
+  pruneopts = ""
   revision = "c12348ce28de40eed0136aa2b644d0ee0650e56c"
   version = "v1.0.1"
 
 [[projects]]
+  digest = "1:6f218995d6a74636cfcab45ce03005371e682b4b9bee0e5eb0ccfd83ef85364f"
   name = "github.com/prometheus/client_golang"
   packages = [
     "prometheus",
-    "prometheus/promhttp"
+    "prometheus/internal",
+    "prometheus/promhttp",
   ]
-  revision = "c5b7fccd204277076155f10851dad72b76a49317"
-  version = "v0.8.0"
+  pruneopts = ""
+  revision = "505eaef017263e299324067d40ca2c48f6a2cf50"
+  version = "v0.9.2"
 
 [[projects]]
   branch = "master"
+  digest = "1:185cf55b1f44a1bf243558901c3f06efa5c64ba62cfdcbb1bf7bbe8c3fb68561"
   name = "github.com/prometheus/client_model"
   packages = ["go"]
+  pruneopts = ""
   revision = "5c3871d89910bfb32f5fcab2aa4b9ec68e65a99f"
 
 [[projects]]
   branch = "master"
+  digest = "1:bfbc121ef802d245ef67421cff206615357d9202337a3d492b8f668906b485a8"
   name = "github.com/prometheus/common"
   packages = [
     "expfmt",
     "internal/bitbucket.org/ww/goautoneg",
-    "model"
+    "model",
   ]
+  pruneopts = ""
   revision = "7600349dcfe1abd18d72d3a1770870d9800a7801"
 
 [[projects]]
   branch = "master"
+  digest = "1:b694a6bdecdace488f507cff872b30f6f490fdaf988abd74d87ea56406b23b6e"
   name = "github.com/prometheus/procfs"
   packages = [
     ".",
     "internal/util",
     "nfs",
-    "xfs"
+    "xfs",
   ]
+  pruneopts = ""
   revision = "ae68e2d4c00fed4943b5f6698d504a5fe083da8a"
 
 [[projects]]
+  digest = "1:f0620375dd1f6251d9973b5f2596228cc8042e887cd7f827e4220bc1ce8c30e2"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
+  pruneopts = ""
   revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
   version = "v2.2.1"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "20ef32caa8bc71b26d6f06b8cbee10c779ee6f542aef2e273ee2718d27475db9"
+  input-imports = [
+    "github.com/aws/aws-sdk-go/aws",
+    "github.com/aws/aws-sdk-go/aws/arn",
+    "github.com/aws/aws-sdk-go/aws/credentials/stscreds",
+    "github.com/aws/aws-sdk-go/aws/session",
+    "github.com/aws/aws-sdk-go/service/cloudwatch",
+    "github.com/aws/aws-sdk-go/service/cloudwatch/cloudwatchiface",
+    "github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi",
+    "github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi/resourcegroupstaggingapiiface",
+    "github.com/prometheus/client_golang/prometheus",
+    "github.com/prometheus/client_golang/prometheus/promhttp",
+    "gopkg.in/yaml.v2",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/src/Gopkg.toml
+++ b/src/Gopkg.toml
@@ -4,4 +4,4 @@
 
 [[constraint]]
   name = "github.com/prometheus/client_golang"
-  version = "0.8.0"
+  version = "0.9.2"

--- a/src/abstract.go
+++ b/src/abstract.go
@@ -74,12 +74,13 @@ func scrapeStaticJob(resource static, clientCloudwatch cloudwatchInterface) (cw 
 			id := resource.Name
 			service := strings.TrimPrefix(resource.Namespace, "AWS/")
 			data := cloudwatchData{
-				ID:         &id,
-				Metric:     &metric.Name,
-				Service:    &service,
-				Statistics: metric.Statistics,
-				NilToZero:  &metric.NilToZero,
-				CustomTags: resource.CustomTags,
+				ID:               &id,
+				Metric:           &metric.Name,
+				Service:          &service,
+				Statistics:       metric.Statistics,
+				NilToZero:        &metric.NilToZero,
+				DisableTimestamp: &metric.DisableTimestamp,
+				CustomTags:       resource.CustomTags,
 			}
 
 			filter := createGetMetricStatisticsInput(
@@ -121,12 +122,13 @@ func scrapeDiscoveryJob(job job, tagsOnMetrics exportedTagsOnMetrics, clientTag 
 				metric := job.Metrics[j]
 				go func() {
 					data := cloudwatchData{
-						ID:         resource.ID,
-						Metric:     &metric.Name,
-						Service:    resource.Service,
-						Statistics: metric.Statistics,
-						NilToZero:  &metric.NilToZero,
-						Tags:       metricTags,
+						ID:               resource.ID,
+						Metric:           &metric.Name,
+						Service:          resource.Service,
+						Statistics:       metric.Statistics,
+						NilToZero:        &metric.NilToZero,
+						DisableTimestamp: &metric.DisableTimestamp,
+						Tags:             metricTags,
 					}
 
 					filter := createGetMetricStatisticsInput(

--- a/src/aws_tags.go
+++ b/src/aws_tags.go
@@ -3,12 +3,13 @@ package main
 import (
 	"context"
 	_ "fmt"
+	"log"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
 	r "github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi"
 	"github.com/aws/aws-sdk-go/service/resourcegroupstaggingapi/resourcegroupstaggingapiiface"
-	"log"
 )
 
 type tagsData struct {
@@ -107,8 +108,8 @@ func (iface tagsInterface) get(job job) (resources []*tagsData, err error) {
 	})
 }
 
-func migrateTagsToPrometheus(tagData []*tagsData) []*prometheusData {
-	output := make([]*prometheusData, 0)
+func migrateTagsToPrometheus(tagData []*tagsData) []*PrometheusMetric {
+	output := make([]*PrometheusMetric, 0)
 
 	tagList := make(map[string][]string)
 
@@ -139,7 +140,7 @@ func migrateTagsToPrometheus(tagData []*tagsData) []*prometheusData {
 		var i int
 		f := float64(i)
 
-		p := prometheusData{
+		p := PrometheusMetric{
 			name:   &name,
 			labels: promLabels,
 			value:  &f,

--- a/src/config.go
+++ b/src/config.go
@@ -2,8 +2,9 @@ package main
 
 import (
 	"fmt"
-	"gopkg.in/yaml.v2"
 	"io/ioutil"
+
+	"gopkg.in/yaml.v2"
 )
 
 type conf struct {
@@ -37,12 +38,13 @@ type static struct {
 }
 
 type metric struct {
-	Name       string   `yaml:"name"`
-	Statistics []string `yaml:"statistics"`
-	Period     int      `yaml:"period"`
-	Length     int      `yaml:"length"`
-	Delay      int      `yaml:"delay"`
-	NilToZero  bool     `yaml:"nilToZero"`
+	Name             string   `yaml:"name"`
+	Statistics       []string `yaml:"statistics"`
+	Period           int      `yaml:"period"`
+	Length           int      `yaml:"length"`
+	Delay            int      `yaml:"delay"`
+	NilToZero        bool     `yaml:"nilToZero"`
+	DisableTimestamp bool     `yaml:"disableTimestamp"`
 }
 
 type dimension struct {

--- a/src/main.go
+++ b/src/main.go
@@ -67,7 +67,7 @@ func main() {
 
 	log.Println("Parse config..")
 	if err := config.load(configFile); err != nil {
-		log.Fatal("Couldn't read config", *configFile, ":", err)
+		log.Fatal("Couldn't read ", *configFile, ":", err)
 	}
 
 	log.Println("Startup completed")


### PR DESCRIPTION
## What

❗️ We are currently on 0.10.0, but this PR is based on 0.11.0 (See https://github.com/alphagov/paas-yet-another-cloudwatch-exporter/pull/2)

* Export metrics with explicit CloudWatch timestamps
* Allow to disable the timestamp per-metric
* Document the configuration

## How to review

Code review

There are no tests currently and we would need to refactor quite some code to add some. We should definitely ask the repo owner before we do that.

## How to merge

We should merge https://github.com/alphagov/paas-yet-another-cloudwatch-exporter/pull/2 first and then change this PR to use gds_master as base.

## Who can review it

Not me.